### PR TITLE
pyparsing pip fix

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -3,4 +3,4 @@ argparse
 httplib2
 prettytable>=0.6.0
 simplejson
-pyparsing
+pyparsing>=1.5.6,<2.0


### PR DESCRIPTION
pyparsing is trying to use 2.0.0, which is python 3 only because of nonlocal use.  1.5.7 is latest for python 2.X but not in pypi as of now.
