### PR TITLE
Add bypass url argument (uses NEUTRONCLIENT_BYPASS_URL environment va…

### DIFF
--- a/neutronclient/client.py
+++ b/neutronclient/client.py
@@ -57,6 +57,8 @@ class HTTPClient(object):
                  endpoint_type='publicURL',
                  auth_strategy='keystone', ca_cert=None, log_credentials=False,
                  service_type='network',
+                 # Neutron API url variable
+                 neutron_api_url=None,
                  **kwargs):
 
         self.username = username
@@ -79,6 +81,11 @@ class HTTPClient(object):
             self.verify_cert = False
         else:
             self.verify_cert = ca_cert if ca_cert else True
+
+        # Neutron API url variable
+        self.neutron_api_url=neutron_api_url
+        if neutron_api_url is not None:
+            self.endpoint_url = self.neutron_api_url	
 
     def _cs_request(self, *args, **kwargs):
         kargs = {}
@@ -361,6 +368,8 @@ def construct_http_client(username=None,
                           ca_cert=None,
                           service_type='network',
                           session=None,
+                          # Neutron API url variable
+                          neutron_api_url=None,
                           **kwargs):
 
     if session:
@@ -369,6 +378,8 @@ def construct_http_client(username=None,
         return SessionClient(session=session,
                              service_type=service_type,
                              region_name=region_name,
+                             # Neutron API url variable
+                             endpoint_override=neutron_api_url,
                              **kwargs)
     else:
         # FIXME(bklei): username and password are now optional. Need
@@ -389,4 +400,6 @@ def construct_http_client(username=None,
                           service_type=service_type,
                           ca_cert=ca_cert,
                           log_credentials=log_credentials,
-                          auth_strategy=auth_strategy)
+                          auth_strategy=auth_strategy,
+                          # Neutron API url variable
+                          neutron_api_url=neutron_api_url)

--- a/neutronclient/common/clientmanager.py
+++ b/neutronclient/common/clientmanager.py
@@ -67,6 +67,8 @@ class ClientManager(object):
                  raise_errors=True,
                  session=None,
                  auth=None,
+		 # Neutron API url variable
+		 neutron_api_url=None
                  ):
         self._token = token
         self._url = url
@@ -90,6 +92,7 @@ class ClientManager(object):
         self._raise_errors = raise_errors
         self._session = session
         self._auth = auth
+	self._neutron_api_url = neutron_api_url
         return
 
     def initialize(self):
@@ -109,7 +112,9 @@ class ClientManager(object):
                 timeout=self._timeout,
                 session=self._session,
                 auth=self._auth,
-                log_credentials=self._log_credentials)
+                log_credentials=self._log_credentials,
+		# Neutron API url variable
+		neutron_api_url=self._neutron_api_url)
             httpclient.authenticate()
             # Populate other password flow attributes
             self._token = httpclient.auth_token

--- a/neutronclient/neutron/client.py
+++ b/neutronclient/neutron/client.py
@@ -50,7 +50,9 @@ def make_client(instance):
                                 retries=instance._retries,
                                 raise_errors=instance._raise_errors,
                                 session=instance._session,
-                                auth=instance._auth)
+                                auth=instance._auth,
+                                # Neutron API url variable
+                                neutron_api_url=instance._neutron_api_url)
         return client
     else:
         raise exceptions.UnsupportedVersion(_("API version %s is not "

--- a/neutronclient/shell.py
+++ b/neutronclient/shell.py
@@ -671,6 +671,18 @@ class NeutronShell(app.App):
                    "not be verified against any certificate authorities. "
                    "This option should be used with caution."))
 
+        # Here we handle the environment variable NEUTRONCLIENT_BYPASS_URL used                                                                                                    
+        # to force neutronclient to use a given neutron API just like what                                                                                                         
+        # NOVACLIENT_BYPASS_URL do.                                                                                                                                                
+        parser.add_argument('--bypass-url',                                                                                                                                        
+            metavar='<bypass-url>',                                                                                                                                            
+            default=env('NEUTRONCLIENT_BYPASS_URL'),                                                                                                                           
+            help=_('Use this API endpoint instead of the Service Catalog'                                                                                                      
+            '. Defaults to env[NEUTRONCLIENT_BYPASS_URL]'))                                                                                                                    
+        parser.add_argument(                                                                                                                                                       
+            '--bypass_url',                                                                                                                                                        
+            help=argparse.SUPPRESS)
+
     def _bash_completion(self):
         """Prints all of the commands and options for bash-completion."""
         commands = set()
@@ -874,7 +886,10 @@ class NeutronShell(app.App):
             raise_errors=False,
             session=auth_session,
             auth=auth,
-            log_credentials=True)
+            log_credentials=True,
+	    # Neutron API url variable
+	    neutron_api_url=self.options.bypass_url)
+
         return
 
     def initialize_app(self, argv):


### PR DESCRIPTION
When dealing with multiple neutron server instances, this variable allows us to specify the neutron API to interact with (just like what bypass_url variable do in Nova).
